### PR TITLE
(feat): configure PostgreSQL role and database

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -23,6 +23,8 @@ default: &default
 development:
   <<: *default
   database: finance_tracker_development
+  username: finance_tracker
+  password:
 
   # The specified database role being used to connect to PostgreSQL.
   # To create additional roles in PostgreSQL see `$ createuser --help`.
@@ -57,6 +59,8 @@ development:
 test:
   <<: *default
   database: finance_tracker_test
+  username: finance_tracker
+  password:
 
 # As with config/credentials.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is


### PR DESCRIPTION
## Summary

This PR sets up the PostgreSQL database for the Finance Tracker app by:
- Configuring `config/database.yml `to use the `finance_tracker` role for development and test environments
- Creating a dedicated PostgreSQL role: `finance_tracker`
- Creating the required databases:
  - `finance_tracker_development`
  - `finance_tracker_test`

## How to Test

1. Ensure PostgreSQL is installed and running locally
2. Run `rails db:create` to verify the databases are created
3. Check with `psql postgres -c "\l"` to confirm