### PR TITLE
(feat): add FactoryBot for testing support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,9 @@ group :development, :test do
 
   # RSpec testing framework [https://rspec.info/]
   gem "rspec-rails", "~> 7.1"
+
+  # FactoryBot library for setting up and creating test data [https://github.com/thoughtbot/factory_bot_rails]
+  gem "factory_bot_rails", "~> 6.4", ">= 6.4.4"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,6 +110,11 @@ GEM
     erubi (1.13.1)
     et-orbi (1.2.11)
       tzinfo
+    factory_bot (6.5.0)
+      activesupport (>= 5.0.0)
+    factory_bot_rails (6.4.4)
+      factory_bot (~> 6.5)
+      railties (>= 5.0.0)
     fugit (1.11.1)
       et-orbi (~> 1, >= 1.2.11)
       raabro (~> 1.4)
@@ -381,6 +386,7 @@ DEPENDENCIES
   brakeman
   capybara
   debug
+  factory_bot_rails (~> 6.4, >= 6.4.4)
   importmap-rails
   jbuilder
   kamal

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -67,4 +67,7 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  # Include FactoryBot methods in your tests
+  config.include FactoryBot::Syntax::Methods
 end


### PR DESCRIPTION
## Purpose

This PR sets up FactoryBot for the Finance Tracker app by:
- Adding the `factory_bot_rails` gem to the `Gemfile` under the `development`, `test` group
- Enabling FactoryBot syntax helpers in `spec/rails_helper.rb`
 -Creating the `spec/factories` directory for defining test data factories