### PR TITLE
(feat): create migration for expenses table

### DIFF
--- a/db/migrate/20250131014457_create_expenses.rb
+++ b/db/migrate/20250131014457_create_expenses.rb
@@ -1,0 +1,12 @@
+class CreateExpenses < ActiveRecord::Migration[8.0]
+  def change
+    create_table :expenses do |t|
+      t.string :name, null: false
+      t.decimal :amount, precision: 12, scale: 2, null: false
+      t.string :category
+      t.date :date, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,25 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[8.0].define(version: 2025_01_31_014457) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "pg_catalog.plpgsql"
+
+  create_table "expenses", force: :cascade do |t|
+    t.string "name", null: false
+    t.decimal "amount", precision: 12, scale: 2, null: false
+    t.string "category"
+    t.date "date", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+end


### PR DESCRIPTION
## Purpose

This PR adds the migration for the expenses table, defining the database structure for expense records by:
- Creating the expenses table with the following fields:
  - `name` - Expense description
  - `amount` - Stores financial amount with precision
  - `category` - Categorizes the expense
  - `date` - Date of the expense
  - `created_at` & `updated_at`

## How to Test

- Run the migration:
```
rails db:migrate
rails db:migrate RAILS_ENV=test
```
- Verify the table was created by opening the Rails console:
```
rails dbconsole
\d expenses
```