### PR TITLE
(feat): Add Expense Model with Validations and RSpec Tests

### DIFF
--- a/app/models/expense.rb
+++ b/app/models/expense.rb
@@ -1,0 +1,2 @@
+class Expense < ApplicationRecord
+end

--- a/app/models/expense.rb
+++ b/app/models/expense.rb
@@ -1,2 +1,5 @@
 class Expense < ApplicationRecord
+  validates :name, presence: true
+  validates :amount, presence: true, numericality: { greater_than: 0 }
+  validates :date, presence: true
 end

--- a/spec/factories/expenses.rb
+++ b/spec/factories/expenses.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :expense do
+    
+  end
+end

--- a/spec/factories/expenses.rb
+++ b/spec/factories/expenses.rb
@@ -1,5 +1,8 @@
 FactoryBot.define do
   factory :expense do
-    
+    name { "Internet Bill" }
+    amount { 69.00 }
+    date { Date.new(2025, 1, 31) }
+    category { "Utilities" }
   end
 end

--- a/spec/models/expense_spec.rb
+++ b/spec/models/expense_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Expense, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/expense_spec.rb
+++ b/spec/models/expense_spec.rb
@@ -1,5 +1,28 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Expense, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  it "is valid with valid attributes" do
+    expense = Expense.new(name: "Internet Bill", amount: 69.00, date: Date.new(2025, 1, 31), category: "Utilities")
+    expect(expense).to be_valid
+  end
+
+  it "is invalid without a name" do
+    expense = Expense.new(amount: 69.00, date: Date.new(2025, 1, 31), category: "Utilities")
+    expect(expense).not_to be_valid
+  end
+
+  it "is invalid without an amount" do
+    expense = Expense.new(name: "Internet Bill", date: Date.new(2025, 1, 31), category: "Utilities")
+    expect(expense).not_to be_valid
+  end
+
+  it "is invalid if the amount is not greater than 0" do
+    expense = Expense.new(name: "Internet Bill", amount: 0, date: Date.new(2025, 1, 31), category: "Utilities")
+    expect(expense).not_to be_valid
+  end
+
+  it "is invalid without a date" do
+    expense = Expense.new(name: "Internet Bill", amount: 69.00, category: "Utilities")
+    expect(expense).not_to be_valid
+  end
 end


### PR DESCRIPTION
## Purpose

This PR implements the Expense model by:
- Adding validations for required fields (`name`, `amount`, `date`)
- Creating a FactoryBot factory for test data generation
- Writing initial RSpec tests to validate model behaviour

## How to Test

1. Ensure dependencies are installed:
  - `bundle install`
2. Run the test suite to verify validations work correctly:
  - `bundle exec rspec`
3. Open the Rails console and try creating an expense:
  - `Expense.create(name: "Internet Bill", amount: 69.00, date: Date.new(2025, 1, 31), category: "Utilities")`