### PR TITLE
(fix): add missing CRUD actions to ExpensesController

### DIFF
--- a/app/controllers/expenses_controller.rb
+++ b/app/controllers/expenses_controller.rb
@@ -1,9 +1,49 @@
 class ExpensesController < ApplicationController
+  def index
+    @expenses = Expense.all
+  end
+
+  def show
+    @expense = Expense.find(params[:id])
+  end
   def new
     @expense = Expense.new
   end
 
+  def create
+    @expense = Expense.new(expense_params)
+
+    if @expense.save
+      redirect_to @expense, notice: "Expense was successfully created."
+    else
+      render :new
+    end
+  end
+
   def edit
     @expense = Expense.find(params[:id])
+  end
+
+  def update
+    @expense = Expense.find(params[:id])
+
+    if @expense.update(expense_params)
+      redirect_to @expense, notice: "Expense was successfully updated."
+    else
+      render :edit
+    end
+  end
+
+  def destroy
+    @expense = Expense.find(params[:id])
+    @expense.destroy
+
+    redirect_to expenses_path, notice: "Expense was successfully deleted."
+  end
+
+  private
+
+  def expense_params
+    params.require(:expense).permit(:name, :amount, :category, :date)
   end
 end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,6 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
 import "@hotwired/turbo-rails"
 import "controllers"
+
+import * as Rails from "@rails/ujs";
+Rails.start();

--- a/app/views/expenses/index.html.erb
+++ b/app/views/expenses/index.html.erb
@@ -6,6 +6,10 @@
             <% @expenses.each do |expense| %>
                 <li>
                     <%= link_to expense.name, expense_path(expense) %> - <%= number_to_currency(expense.amount) %>
+                    |
+                    <%= link_to "Edit", edit_expense_path(expense) %>
+                    |
+                    <%= link_to "Delete", expense_path(expense), method: :delete, data: { confirm: "Are you sure?" } %>
                 </li>
             <% end %>
         </ul>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,6 +20,7 @@
     <%# Includes all stylesheet files in app/assets/stylesheets %>
     <%= stylesheet_link_tag :app, "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
+    <%= javascript_include_tag "application", "data-turbo-track": "reload" %>
   </head>
 
   <body>

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -5,3 +5,5 @@ pin "@hotwired/turbo-rails", to: "turbo.min.js"
 pin "@hotwired/stimulus", to: "stimulus.min.js"
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js"
 pin_all_from "app/javascript/controllers", under: "controllers"
+
+pin "@rails/ujs", to: "rails-ujs.js"

--- a/spec/requests/expenses_spec.rb
+++ b/spec/requests/expenses_spec.rb
@@ -1,7 +1,64 @@
 require 'rails_helper'
 
 RSpec.describe "Expenses", type: :request do
-  describe "GET /index" do
-    pending "add some examples (or delete) #{__FILE__}"
+  let!(:expense) { create(:expense) }
+
+  describe "GET /expenses" do
+    it 'returns a list of expenses' do
+      get '/expenses'
+      expect(response).to have_http_status(200)
+      expect(response.body).to include(expense.name)
+    end
+  end
+
+  describe "GET /expenses/:id" do
+    it 'returns a single expense' do
+      get "/expenses/#{expense.id}"
+      expect(response).to have_http_status(200)
+      expect(response.body).to include(expense.name)
+    end
+  end
+
+  describe "GET /expenses/new" do
+    it 'returns a form for a new expense' do
+      get '/expenses/new'
+      expect(response).to have_http_status(200)
+    end
+  end
+
+  describe "POST /expenses" do
+    it 'creates a new expense' do
+      expense_params = { expense: { name: "Electricity Bill", amount: 250.00, date: Date.new(2025, 2, 1), category: "Utilities" } }
+
+      expect { post '/expenses', params: expense_params }.to change(Expense, :count).by(1)
+      expect(response).to redirect_to(Expense.last)
+      follow_redirect!
+      expect(response.body).to include(Expense.last.name)
+    end
+  end
+
+  describe "GET /expenses/:id/edit" do
+    it 'returns a form to edit an expense' do
+      get "/expenses/#{expense.id}/edit"
+      expect(response).to have_http_status(200)
+    end
+  end
+
+  describe "PATCH /expenses/:id" do
+    it 'updates an expense' do
+      updated_expense_params = { expense: { name: "Updated Bill", amount: 275.00 } }
+
+      patch "/expenses/#{expense.id}", params: updated_expense_params
+      expect(response).to redirect_to(expense)
+      follow_redirect!
+      expect(response.body).to include(expense.reload.name)
+    end
+  end
+
+  describe "DELETE /expenses/:id" do
+    it 'deletes an expense' do
+      expect { delete "/expenses/#{expense.id}" }.to change(Expense, :count).by(-1)
+      expect(response).to redirect_to(expenses_path)
+    end
   end
 end


### PR DESCRIPTION
##Purpose

This PR adds the missing CRUD actions to the `ExpensesController` by:
- Implementing the `create`, `update`, and `destroy` actions.
- Fixing the Rails UJS import to properly handle `DELETE` requests.
- Adding RSpec request specs to test all CRUD actions.

## How to Test

1. Ensure the Rails server is running: `rails s`
2. Verify CRUD operations manually in the browser:
  - Navigate to `http://localhost:3000/expenses`.
  - Create a new expense and confirm it appears on the index page.
  - Edit an existing expense and verify the changes persist.
  - Delete an expense and ensure it is removed.
3. Run the RSpec request specs and ensure all tests pass: `rspec spec/requests/expenses_spec.rb`