### PR TITLE
(chore): add tailwindcss-rails gem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+
+/app/assets/builds/*
+!/app/assets/builds/.keep

--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,9 @@ gem "stimulus-rails"
 # Build JSON APIs with ease [https://github.com/rails/jbuilder]
 gem "jbuilder"
 
+# Add Tailwind CSS for styling
+gem "tailwindcss-rails", "~> 4.0"
+
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
 # gem "bcrypt", "~> 3.1.7"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -341,6 +341,16 @@ GEM
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
     stringio (3.1.2)
+    tailwindcss-rails (4.0.0)
+      railties (>= 7.0.0)
+      tailwindcss-ruby (~> 4.0)
+    tailwindcss-ruby (4.0.6)
+    tailwindcss-ruby (4.0.6-aarch64-linux-gnu)
+    tailwindcss-ruby (4.0.6-aarch64-linux-musl)
+    tailwindcss-ruby (4.0.6-arm64-darwin)
+    tailwindcss-ruby (4.0.6-x86_64-darwin)
+    tailwindcss-ruby (4.0.6-x86_64-linux-gnu)
+    tailwindcss-ruby (4.0.6-x86_64-linux-musl)
     thor (1.3.2)
     thruster (0.1.11)
     thruster (0.1.11-aarch64-linux)
@@ -405,6 +415,7 @@ DEPENDENCIES
   solid_cache
   solid_queue
   stimulus-rails
+  tailwindcss-rails (~> 4.0)
   thruster
   turbo-rails
   tzinfo-data

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,0 +1,2 @@
+web: bin/rails server
+css: bin/rails tailwindcss:watch

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -1,0 +1,1 @@
+@import "tailwindcss";

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,6 +24,8 @@
   </head>
 
   <body>
-    <%= yield %>
+    <main class="container mx-auto mt-28 px-5 flex">
+      <%= yield %>
+    </main>
   </body>
 </html>

--- a/bin/dev
+++ b/bin/dev
@@ -1,2 +1,16 @@
-#!/usr/bin/env ruby
-exec "./bin/rails", "server", *ARGV
+#!/usr/bin/env sh
+
+if ! gem list foreman -i --silent; then
+  echo "Installing foreman..."
+  gem install foreman
+fi
+
+# Default to port 3000 if not specified
+export PORT="${PORT:-3000}"
+
+# Let the debug gem allow remote connections,
+# but avoid loading until `debugger` is called
+export RUBY_DEBUG_OPEN="true"
+export RUBY_DEBUG_LAZY="true"
+
+exec foreman start -f Procfile.dev "$@"


### PR DESCRIPTION
## Purpose

This PR sets up Tailwind CSS for the Finance Tracker app by:
- Adding the `tailwindcss-rails` gem to the `Gemfile`
- Running `bin/rails tailwindcss:install` to generate the necessary Tailwind files