### PR TITLE
(feat): update base font to Poppins

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,13 +17,15 @@
     <link rel="icon" href="/icon.svg" type="image/svg+xml">
     <link rel="apple-touch-icon" href="/icon.png">
 
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap" rel="stylesheet">
+
     <%# Includes all stylesheet files in app/assets/stylesheets %>
     <%= stylesheet_link_tag :app, "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload" %>
   </head>
 
-  <body>
+  <body style="font-family: 'Poppins', sans-serif;">
     <div class="flex h-screen">
       <!-- Sidebar -->
       <%= render "shared/sidebar" %>


### PR DESCRIPTION
## Purpose

This PR updates the app's font family by adding the Poppins font for a more modern and clean look.

## Screenshots

**Before**:
<img width="842" alt="Screenshot 2025-03-17 at 7 20 08 PM" src="https://github.com/user-attachments/assets/880fa348-2d56-43a7-bfe7-a36d70a2891b" />

**After**:
<img width="873" alt="Screenshot 2025-03-17 at 7 20 22 PM" src="https://github.com/user-attachments/assets/802b6abe-c579-473f-93cc-6ed314cd9dcd" />