### PR TITLE
(feat): style Expenses table with month grouping and dark mode layout

### DIFF
--- a/app/views/expenses/index.html.erb
+++ b/app/views/expenses/index.html.erb
@@ -1,31 +1,31 @@
-<h1>All Expenses</h1>
+<h1 class="text-2xl font-semibold text-white mb-6">All Expenses</h1>
 
-<table class="w-full">
+<table class="w-full bg-indigo-800 rounded-lg overflow-hidden">
   <thead>
-    <tr>
-      <th class="text-left px-4 py-2 border-b">Name</th>
-      <th class="text-left px-4 py-2 border-b">Amount</th>
-      <th class="text-left px-4 py-2 border-b">Category</th>
-      <th class="text-left px-4 py-2 border-b">Date</th>
-      <th class="text-left px-4 py-2 border-b">Actions</th>
+    <tr class="bg-indigo-700 text-white">
+      <th class="text-left px-6 py-3 border-b border-indigo-600">Name</th>
+      <th class="text-left px-6 py-3 border-b border-indigo-600">Amount</th>
+      <th class="text-left px-6 py-3 border-b border-indigo-600">Category</th>
+      <th class="text-left px-6 py-3 border-b border-indigo-600">Date</th>
+      <th class="text-left px-6 py-3 border-b border-indigo-600">Actions</th>
     </tr>
   </thead>
   <tbody>
     <% @expenses.group_by { |e| e.date.strftime("%B %Y") }.each do |month, expenses| %>
       <tr>
-        <td colspan="5" class="font-semibold px-4 py-2"><%= month %></td>
+        <td colspan="5" class="font-semibold text-indigo-400 px-4 py-2 bg-indigo-800 rounded-t"><%= month %></td>
       </tr>
 
       <% expenses.each do |expense| %>
-        <tr>
-          <td class="px-4 py-2"><%= expense.name %></td>
-          <td class="px-4 py-2"><%= number_to_currency(expense.amount) %></td>
-          <td class="px-4 py-2"><%= expense.category %></td>
-          <td class="px-4 py-2"><%= expense.date.strftime("%B %d, %Y") %></td>
-          <td class="px-4 py-2">
-            <%= link_to "Show", expense_path(expense) %>
-            <%= link_to "Edit", edit_expense_path(expense) %>
-            <%= link_to "Delete", expense_path(expense), method: :delete, data: { confirm: "Are you sure?" } %>
+        <tr class="text-white hover:bg-indigo-700 transition">
+          <td class="px-6 py-3 border-b border-indigo-700"><%= expense.name %></td>
+          <td class="px-6 py-3 border-b border-indigo-700"><%= number_to_currency(expense.amount) %></td>
+          <td class="px-6 py-3 border-b border-indigo-700"><%= expense.category %></td>
+          <td class="px-6 py-3 border-b border-indigo-700"><%= expense.date.strftime("%B %d, %Y") %></td>
+          <td class="px-6 py-3 border-b border-indigo-700">
+            <%= link_to "Show", expense_path(expense), class: "underline text-violet-300 hover:text-white mr-2" %>
+            <%= link_to "Edit", edit_expense_path(expense), class: "underline text-violet-300 hover:text-white mr-2" %>
+            <%= link_to "Delete", expense_path(expense), method: :delete, data: { confirm: "Are you sure?" }, class: "underline text-red-400 hover:text-white" %>
           </td>
         </tr>
       <% end %>

--- a/app/views/expenses/index.html.erb
+++ b/app/views/expenses/index.html.erb
@@ -1,4 +1,7 @@
-<h1 class="text-2xl font-semibold text-white mb-6">All Expenses</h1>
+<div class="flex justify-between items-center mb-4">
+  <h1 class="text-white text-2xl font-semibold">All Expenses</h1>
+  <%= link_to "New Expense", new_expense_path, class: "bg-indigo-600 hover:bg-indigo-500 text-white font-medium py-2 px-4 rounded-lg transition-colors" %>
+</div>
 
 <table class="w-full bg-indigo-800 rounded-lg overflow-hidden">
   <thead>
@@ -23,8 +26,8 @@
           <td class="px-6 py-3 border-b border-indigo-700"><%= expense.category %></td>
           <td class="px-6 py-3 border-b border-indigo-700"><%= expense.date.strftime("%B %d, %Y") %></td>
           <td class="px-6 py-3 border-b border-indigo-700">
-            <%= link_to "Show", expense_path(expense), class: "underline text-violet-300 hover:text-white mr-2" %>
-            <%= link_to "Edit", edit_expense_path(expense), class: "underline text-violet-300 hover:text-white mr-2" %>
+            <%= link_to "Show", expense_path(expense), class: "underline text-indigo-300 hover:text-white mr-2" %>
+            <%= link_to "Edit", edit_expense_path(expense), class: "underline text-indigo-300 hover:text-white mr-2" %>
             <%= link_to "Delete", expense_path(expense), method: :delete, data: { confirm: "Are you sure?" }, class: "underline text-red-400 hover:text-white" %>
           </td>
         </tr>
@@ -32,5 +35,3 @@
     <% end %>
   </tbody>
 </table>
-
-<%= link_to "New Expense", new_expense_path %>

--- a/app/views/expenses/index.html.erb
+++ b/app/views/expenses/index.html.erb
@@ -1,38 +1,36 @@
 <h1>All Expenses</h1>
 
-<% @expenses.group_by { |e| e.date.strftime("%B %Y") }.each do |month, expenses| %>
-    <h2><%= month %></h2>
-    <table>
-        <thead>
-            <tr>
-                <th>Name</th>
-                <th>Amount</th>
-                <th>Category</th>
-                <th>Date</th>
-                <th>Actions</th>
-            </tr>
-        </thead>
-        <tbody>
-            <% expenses.each do |expense| %>
-                <tr>
-                    <td><%= expense.name %></td>
-                    <td><%= number_to_currency(expense.amount) %></td>
-                    <td><%= expense.category %></td>
-                    <td><%= expense.date.strftime("%B %d, %Y") %></td>
-                    <td>
-                        <%= link_to "Show", expense_path(expense) %>
-                        <%= link_to "Edit", edit_expense_path(expense) %>
-                        <%= link_to "Delete", expense_path(expense), method: :delete, data: { confirm: "Are you sure?" } %>
-                    </td>
-                </tr>
-            <% end %>
+<table class="w-full">
+  <thead>
+    <tr>
+      <th class="text-left px-4 py-2 border-b">Name</th>
+      <th class="text-left px-4 py-2 border-b">Amount</th>
+      <th class="text-left px-4 py-2 border-b">Category</th>
+      <th class="text-left px-4 py-2 border-b">Date</th>
+      <th class="text-left px-4 py-2 border-b">Actions</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @expenses.group_by { |e| e.date.strftime("%B %Y") }.each do |month, expenses| %>
+      <tr>
+        <td colspan="5" class="font-semibold px-4 py-2"><%= month %></td>
+      </tr>
 
-            <tr>
-                <td colspan="5"><hr></td>
-            </tr>
-
-        </tbody>
-    </table>
-<% end %>
+      <% expenses.each do |expense| %>
+        <tr>
+          <td class="px-4 py-2"><%= expense.name %></td>
+          <td class="px-4 py-2"><%= number_to_currency(expense.amount) %></td>
+          <td class="px-4 py-2"><%= expense.category %></td>
+          <td class="px-4 py-2"><%= expense.date.strftime("%B %d, %Y") %></td>
+          <td class="px-4 py-2">
+            <%= link_to "Show", expense_path(expense) %>
+            <%= link_to "Edit", edit_expense_path(expense) %>
+            <%= link_to "Delete", expense_path(expense), method: :delete, data: { confirm: "Are you sure?" } %>
+          </td>
+        </tr>
+      <% end %>
+    <% end %>
+  </tbody>
+</table>
 
 <%= link_to "New Expense", new_expense_path %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -31,7 +31,7 @@
       <%= render "shared/sidebar" %>
 
       <!-- Main Content -->
-      <main class="flex-1 p-8">
+      <main class="flex-1 p-8 bg-indigo-900">
         <%= yield %>
       </main>
     </div>

--- a/app/views/shared/_sidebar.html.erb
+++ b/app/views/shared/_sidebar.html.erb
@@ -1,7 +1,7 @@
 <div class="lg:w-1/6 p-8 bg-indigo-950 text-white min-h-screen">
   <nav>
     <ul>
-      <li><%= link_to "Expenses", expenses_path, class: "block px-4 py-2 rounded #{current_page?(expenses_path) ? 'bg-gradient-to-r from-indigo-900 to-violet-500 text-white' : 'hover:bg-indigo-900'}" %></li>
+      <li><%= link_to "Expenses", expenses_path, class: "block px-4 py-2 rounded #{current_page?(expenses_path) ? 'bg-gradient-to-r from-indigo-900 to-indigo-500 text-white' : 'hover:bg-indigo-900'}" %></li>
     </ul>
   </nav>
 </div>


### PR DESCRIPTION
## Purpose

This PR updates the expenses table layout and styling for better scalability, grouping rows by month and applying improved dark mode visuals for a cleaner user experience.

## Screenshots

**Before**:
<img width="1427" alt="Screenshot 2025-03-25 at 9 15 57 AM" src="https://github.com/user-attachments/assets/24b7101d-9f7f-445f-a1e5-c0d590fe875b" />

**After**:
<img width="1423" alt="Screenshot 2025-03-25 at 11 15 43 AM" src="https://github.com/user-attachments/assets/9f2753a0-1964-4b71-b592-53b9ca8162ba" />