### PR TITLE
(feat): style New, Show, and Edit Expense pages

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -8,3 +8,12 @@
  *
  * Consider organizing styles into separate files for maintainability.
  */
+
+ input:-webkit-autofill,
+input:-webkit-autofill:hover,
+input:-webkit-autofill:focus,
+input:-webkit-autofill:active {
+  -webkit-box-shadow: 0 0 0px 1000px #3730a3 inset; /* bg-indigo-800 */
+  -webkit-text-fill-color: white;
+  transition: background-color 5000s ease-in-out 0s;
+}

--- a/app/views/expenses/edit.html.erb
+++ b/app/views/expenses/edit.html.erb
@@ -26,7 +26,7 @@
     </div>
 
     <div>
-      <%= f.submit "Update Expense", class: "bg-indigo-500 hover:bg-indigo-600 text-white font-medium py-2 px-4 rounded-md transition" %>
+      <%= f.submit "Update Expense", class: "bg-indigo-500 hover:bg-indigo-600 text-white font-medium py-2 px-4 rounded-md transition cursor-pointer" %>
     </div>
   </div>
 <% end %>

--- a/app/views/expenses/edit.html.erb
+++ b/app/views/expenses/edit.html.erb
@@ -1,29 +1,32 @@
-<h1>Update Expense</h1>
+<div class="flex justify-between items-center mb-6">
+  <h1 class="text-2xl font-semibold text-white">Update Expense</h1>
+  <%= link_to "Back", expenses_path, class: "text-indigo-300 hover:underline" %>
+</div>
 
 <%= form_with model: @expense, local: true do |f| %>
-  <p>
-    <%= f.label :name %><br>
-    <%= f.text_field :name %>
-  </p>
+  <div class="space-y-6">
+    <div>
+      <%= f.label :name, class: "block text-sm font-medium text-indigo-300" %>
+      <%= f.text_field :name, class: "mt-1 block w-full rounded-md bg-indigo-800 text-white border border-indigo-600 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-400" %>
+    </div>
 
-  <p>
-    <%= f.label :amount %><br>
-    <%= f.number_field :amount %>
-  </p>
+    <div>
+      <%= f.label :amount, class: "block text-sm font-medium text-indigo-300" %>
+      <%= f.number_field :amount, class: "mt-1 block w-full rounded-md bg-indigo-800 text-white border border-indigo-600 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-400" %>
+    </div>
 
-  <p>
-    <%= f.label :category %><br>
-    <%= f.text_field :category %>
-  </p>
+    <div>
+      <%= f.label :category, class: "block text-sm font-medium text-indigo-300" %>
+      <%= f.text_field :category, class: "mt-1 block w-full rounded-md bg-indigo-800 text-white border border-indigo-600 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-400" %>
+    </div>
 
-  <p>
-    <%= f.label :date %><br>
-    <%= f.date_field :date %>
-  </p>
+    <div>
+      <%= f.label :date, class: "block text-sm font-medium text-indigo-300" %>
+      <%= f.date_field :date, class: "mt-1 block w-full rounded-md bg-indigo-800 text-white border border-indigo-600 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-400" %>
+    </div>
 
-  <p>
-    <%= f.submit "Update Expense" %>
-  </p>
+    <div>
+      <%= f.submit "Update Expense", class: "bg-indigo-500 hover:bg-indigo-600 text-white font-medium py-2 px-4 rounded-md transition" %>
+    </div>
+  </div>
 <% end %>
-
-<%= link_to "Back", expenses_path %>

--- a/app/views/expenses/index.html.erb
+++ b/app/views/expenses/index.html.erb
@@ -27,7 +27,7 @@
           <td class="px-6 py-3 border-b border-indigo-700"><%= expense.date.strftime("%B %d, %Y") %></td>
           <td class="px-6 py-3 border-b border-indigo-700">
             <%= link_to "Show", expense_path(expense), class: "underline text-indigo-300 hover:text-white mr-2" %>
-            <%= link_to "Edit", edit_expense_path(expense), class: "underline text-indigo-300 hover:text-white mr-2" %>
+            <%= link_to "Update", edit_expense_path(expense), class: "underline text-indigo-300 hover:text-white mr-2" %>
             <%= link_to "Delete", expense_path(expense), method: :delete, data: { confirm: "Are you sure?" }, class: "underline text-red-400 hover:text-white" %>
           </td>
         </tr>

--- a/app/views/expenses/new.html.erb
+++ b/app/views/expenses/new.html.erb
@@ -1,5 +1,5 @@
 <div class="flex justify-between items-center mb-6">
-  <h1 class="text-2xl font-semibold text-white">Add a New Expense</h1>
+  <h1 class="text-2xl font-semibold text-white">Add New Expense</h1>
   <%= link_to "Back", expenses_path, class: "text-indigo-300 hover:underline" %>
 </div>
 
@@ -26,7 +26,7 @@
     </div>
 
     <div>
-      <%= f.submit "Add Expense", class: "bg-indigo-500 hover:bg-indigo-600 text-white font-medium py-2 px-4 rounded-md transition" %>
+      <%= f.submit "Add Expense", class: "bg-indigo-500 hover:bg-indigo-600 text-white font-medium py-2 px-4 rounded-md transition cursor-pointer" %>
     </div>
   </div>
 <% end %>

--- a/app/views/expenses/new.html.erb
+++ b/app/views/expenses/new.html.erb
@@ -1,29 +1,32 @@
-<h1>Create a New Expense</h1>
+<div class="flex justify-between items-center mb-6">
+  <h1 class="text-2xl font-semibold text-white">Add a New Expense</h1>
+  <%= link_to "Back", expenses_path, class: "text-indigo-300 hover:underline" %>
+</div>
 
 <%= form_with model: @expense, local: true do |f| %>
-  <p>
-    <%= f.label :name %><br>
-    <%= f.text_field :name %>
-  </p>
+  <div class="space-y-6">
+    <div>
+      <%= f.label :name, class: "block text-sm font-medium text-indigo-300" %>
+      <%= f.text_field :name, class: "mt-1 block w-full rounded-md bg-indigo-800 text-white border border-indigo-600 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-400" %>
+    </div>
 
-  <p>
-    <%= f.label :amount %><br>
-    <%= f.number_field :amount %>
-  </p>
+    <div>
+      <%= f.label :amount, class: "block text-sm font-medium text-indigo-300" %>
+      <%= f.number_field :amount, class: "mt-1 block w-full rounded-md bg-indigo-800 text-white border border-indigo-600 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-400" %>
+    </div>
 
-  <p>
-    <%= f.label :category %><br>
-    <%= f.text_field :category %>
-  </p>
+    <div>
+      <%= f.label :category, class: "block text-sm font-medium text-indigo-300" %>
+      <%= f.text_field :category, class: "mt-1 block w-full rounded-md bg-indigo-800 text-white border border-indigo-600 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-400" %>
+    </div>
 
-  <p>
-    <%= f.label :date %><br>
-    <%= f.date_field :date %>
-  </p>
+    <div>
+      <%= f.label :date, class: "block text-sm font-medium text-indigo-300" %>
+      <%= f.date_field :date, class: "mt-1 block w-full rounded-md bg-indigo-800 text-white border border-indigo-600 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-400" %>
+    </div>
 
-  <p>
-    <%= f.submit "Create Expense" %>
-  </p>
+    <div>
+      <%= f.submit "Add Expense", class: "bg-indigo-500 hover:bg-indigo-600 text-white font-medium py-2 px-4 rounded-md transition" %>
+    </div>
+  </div>
 <% end %>
-
-<%= link_to "Back", expenses_path %>

--- a/app/views/expenses/show.html.erb
+++ b/app/views/expenses/show.html.erb
@@ -1,8 +1,24 @@
-<h1><%= @expense.name %></h1>
+<div class="max-w-2xl mt-10 ml-12 text-white space-y-4">
+  <h1 class="text-2xl font-semibold"><%= @expense.name %></h1>
 
-<p><strong>Amount:</strong> <%= number_to_currency(@expense.amount) %></p>
-<p><strong>Category:</strong> <%= @expense.category %></p>
-<p><strong>Date:</strong> <%= @expense.date.strftime("%B %d, %Y") %></p>
+  <p>
+    <span class="font-medium text-indigo-300">Amount:</span>
+    $<%= number_with_precision(@expense.amount, precision: 2) %>
+  </p>
 
-<%= link_to "Edit", edit_expense_path(@expense) if @expense %> |
-<%= link_to "Back to Expenses", expenses_path %>
+  <p>
+    <span class="font-medium text-indigo-300">Category:</span>
+    <%= @expense.category %>
+  </p>
+
+  <p>
+    <span class="font-medium text-indigo-300">Date:</span>
+    <%= @expense.date.strftime("%B %d, %Y") %>
+  </p>
+
+  <div class="pt-4 space-x-4">
+    <%= link_to "Edit", edit_expense_path(@expense), class: "text-indigo-400 hover:underline" %>
+    <span class="text-gray-500">|</span>
+    <%= link_to "Back to Expenses", expenses_path, class: "text-indigo-400 hover:underline" %>
+  </div>
+</div>


### PR DESCRIPTION
## Purpose

This PR styles the New, Show, and Update Expense pages to match the updated table layout and improve the overall look and feel.

## Screenshots

**New Expense Before**:
<img width="1423" alt="new-expense-before" src="https://github.com/user-attachments/assets/4d14eb68-2a62-48bf-95f5-7844ab7d6f65" />
**New Expense After**:
<img width="1423" alt="new-expense-after" src="https://github.com/user-attachments/assets/d0efc598-9104-49ba-8563-c69c6fce6be7" />

**Show Expense Before**:
<img width="1423" alt="show-expense-before" src="https://github.com/user-attachments/assets/5d792e90-2d8f-41db-81e6-d79aaac1e532" />
**Show Expense After**:
<img width="1423" alt="show-expense-after" src="https://github.com/user-attachments/assets/5046a0db-de9a-4d39-b3b6-d7d1222f3255" />

**Update Expense Before**:
<img width="1423" alt="edit-expense-before" src="https://github.com/user-attachments/assets/fb5d7693-407b-4ff9-839b-fb61f4bedee9" />
**Update Expense After*:
<img width="1423" alt="edit-expense-after" src="https://github.com/user-attachments/assets/754edb8a-b473-407d-a97c-db0a09e1e7b9" />