### PR TITLE
(test): add basic sign up, login, and logout links to layout

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -32,6 +32,17 @@
 
       <!-- Main Content -->
       <main class="flex-1 p-8 bg-indigo-900">
+        <!-- 🔐 Devise Auth Links (for testing) -->
+        <div class="mb-4 space-x-4 text-indigo-300">
+          <% if user_signed_in? %>
+            <span>Welcome, <%= current_user.email %>!</span>
+            <%= link_to "Log out", destroy_user_session_path, method: :delete %>
+          <% else %>
+            <%= link_to "Sign up", new_user_registration_path %>
+            <%= link_to "Log in", new_user_session_path %>
+          <% end %>
+        </div>
+        
         <%= yield %>
       </main>
     </div>


### PR DESCRIPTION
## Purpose

This PR adds basic Devise authentication links to the main layout for testing purposes, including:

- Sign up link → `new_user_registration_path`
- Log in link → `new_user_session_path`
- Log out link → `destroy_user_session_path` (using method: :delete)

## How to Test

1. Start the server: `rails s`
2. Visit `http://localhost:3000`
3. Use the Sign up link to register a new user
4. Use the Log in / Log out links to verify session behaviour
5. Check that the welcome message shows the correct signed-in user email