### PR TITLE
(feat): require login to access Expense routes

### DIFF
--- a/app/controllers/expenses_controller.rb
+++ b/app/controllers/expenses_controller.rb
@@ -1,4 +1,5 @@
 class ExpensesController < ApplicationController
+  before_action :authenticate_user!
   def index
     @expenses = Expense.all
   end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -28,7 +28,7 @@
   <body style="font-family: 'Poppins', sans-serif;">
     <div class="flex h-screen">
       <!-- Sidebar -->
-      <%= render "shared/sidebar" %>
+      <%= render "shared/sidebar" if user_signed_in? %>
 
       <!-- Main Content -->
       <main class="flex-1 p-8 bg-indigo-900">


### PR DESCRIPTION
## Purpose

This PR makes sure that guest users don’t have access to the expense dashboard or any app functionality beyond signing up and logging in by:

- Requiring users to be authenticated to access any Expense-related routes
- Conditionally rendering the sidebar only when a user is logged in

## Screen Recording

https://github.com/user-attachments/assets/4625cd5d-dd18-4431-8ee4-a2d67d5b34b3