### PR TITLE
(chore): add rubocop-rails gem to support Rails-specific linting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,9 @@ group :development, :test do
   # Omakase Ruby styling [https://github.com/rails/rubocop-rails-omakase/]
   gem "rubocop-rails-omakase", require: false
 
+  # Rails-specific cops for RuboCop
+  gem "rubocop-rails", require: false
+
   # RSpec testing framework [https://rspec.info/]
   gem "rspec-rails", "~> 7.1"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -422,6 +422,7 @@ DEPENDENCIES
   puma (>= 5.0)
   rails (~> 8.0.2)
   rspec-rails (~> 7.1)
+  rubocop-rails
   rubocop-rails-omakase
   selenium-webdriver
   shoulda-matchers (~> 6.4)


### PR DESCRIPTION
## Purpose

This PR resolves a RuboCop linting error caused by missing Rails-specific cops by:

- Adding the `rubocop-rails` gem to the `Gemfile` under the `:development, :test group`
- Running `bundle install` to make it available for linting checks