### PR TITLE
(style): add custom layout and styling for Devise sign up and login pages

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,16 @@
 class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
+
+  layout :layout_by_resource
+
+  private
+
+  def layout_by_resource
+    if devise_controller?
+      "devise"
+    else
+      "application"
+    end
+  end
 end

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,29 +1,37 @@
-<h2>Sign up</h2>
+<div class="flex items-center justify-center min-h-screen bg-indigo-900 text-white">
+  <div class="w-full max-w-md p-8 space-y-6 bg-indigo-950 rounded-xl shadow-lg">
+    <h2 class="text-2xl font-bold text-center">Create an Account</h2>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+    <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+      <%= render "devise/shared/error_messages", resource: resource %>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+      <div class="space-y-4">
+        <div>
+          <%= f.label :email, class: "block text-sm font-medium text-white" %>
+          <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "mt-1 block w-full rounded-md bg-indigo-800 text-white border border-indigo-600 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-400" %>
+        </div>
+
+        <div>
+          <%= f.label :password, class: "block mb-1 text-sm font-medium text-white" %>
+          <% if @minimum_password_length %>
+            <p class="text-xs mb-1 text-indigo-300">(<%= @minimum_password_length %> characters minimum)</p>
+          <% end %>
+          <%= f.password_field :password, autocomplete: "new-password", class: "mt-1 block w-full rounded-md bg-indigo-800 text-white border border-indigo-600 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-400" %>
+        </div>
+
+        <div>
+          <%= f.label :password_confirmation, class: "block mb-1 text-sm font-medium text-white" %>
+          <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "mt-1 block w-full rounded-md bg-indigo-800 text-white border border-indigo-600 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-400" %>
+        </div>
+
+        <div>
+          <%= f.submit "Sign up", class: "w-full bg-indigo-500 hover:bg-indigo-600 text-white font-semibold py-2 px-4 rounded-lg transition duration-150 ease-in-out cursor-pointer" %>
+        </div>
+      </div>
+    <% end %>
+
+    <div class="text-center text-sm mt-4">
+      <%= render "devise/shared/links" %>
+    </div>
   </div>
-
-  <div class="field">
-    <%= f.label :password %>
-    <% if @minimum_password_length %>
-    <em>(<%= @minimum_password_length %> characters minimum)</em>
-    <% end %><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Sign up" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,26 +1,36 @@
-<h2>Log in</h2>
+<div class="flex items-center justify-center min-h-screen bg-indigo-900 text-white">
+  <div class="w-full max-w-md p-8 space-y-6 bg-indigo-950 rounded-xl shadow-lg">
+    <h2 class="text-2xl font-bold text-center">Log in</h2>
 
-<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-  </div>
+    <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+      <%= render "devise/shared/error_messages", resource: resource %>
 
-  <div class="field">
-    <%= f.label :password %><br />
-    <%= f.password_field :password, autocomplete: "current-password" %>
-  </div>
+      <div class="space-y-4">
+        <div>
+          <%= f.label :email, class: "block text-sm font-medium text-white" %>
+          <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "mt-1 block w-full rounded-md bg-indigo-800 text-white border border-indigo-600 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-400" %>
+        </div>
 
-  <% if devise_mapping.rememberable? %>
-    <div class="field">
-      <%= f.check_box :remember_me %>
-      <%= f.label :remember_me %>
+        <div>
+          <%= f.label :password, class: "block text-sm font-medium text-white" %>
+          <%= f.password_field :password, autocomplete: "current-password", class: "mt-1 block w-full rounded-md bg-indigo-800 text-white border border-indigo-600 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-400" %>
+        </div>
+
+        <% if devise_mapping.rememberable? -%>
+          <div class="flex items-center">
+            <%= f.check_box :remember_me, class: "mr-2" %>
+            <%= f.label :remember_me, class: "text-sm text-white" %>
+          </div>
+        <% end -%>
+
+        <div>
+          <%= f.submit "Log in", class: "w-full bg-indigo-500 hover:bg-indigo-600 text-white font-semibold py-2 px-4 rounded-lg transition duration-150 ease-in-out cursor-pointer" %>
+        </div>
+      </div>
+    <% end %>
+
+    <div class="text-center text-sm mt-4">
+      <%= render "devise/shared/links" %>
     </div>
-  <% end %>
-
-  <div class="actions">
-    <%= f.submit "Log in" %>
   </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/app/views/layouts/devise.html.erb
+++ b/app/views/layouts/devise.html.erb
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Finance Tracker – Authentication</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <%= stylesheet_link_tag :app, "data-turbo-track": "reload" %>
+    <%= javascript_importmap_tags %>
+    <%= javascript_include_tag "application", "data-turbo-track": "reload" %>
+  </head>
+
+  <body  style="font-family: 'Poppins', sans-serif;">
+    <%= yield %>
+  </body>
+</html>


### PR DESCRIPTION
## Purpose

This PR updates the look and feel of the Devise Sign Up and Login pages to match the rest of the app using Tailwind CSS and a custom layout.

## Screenshots

**Sign Up**:
<img width="1427" alt="Screenshot 2025-04-06 at 4 38 34 PM" src="https://github.com/user-attachments/assets/b11a3ac5-9b99-4d4c-8ec8-c38ce7766cb4" />

**Login**:
<img width="1427" alt="Screenshot 2025-04-06 at 4 57 50 PM" src="https://github.com/user-attachments/assets/9363a00b-812f-4e3e-9807-bc449e0d3850" />