### PR TITLE
(chore): add user reference to expenses table

### DIFF
--- a/db/migrate/20250409231038_add_user_to_expenses.rb
+++ b/db/migrate/20250409231038_add_user_to_expenses.rb
@@ -1,0 +1,5 @@
+class AddUserToExpenses < ActiveRecord::Migration[8.0]
+  def change
+    add_reference :expenses, :user, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_04_02_171715) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_09_231038) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -21,6 +21,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_02_171715) do
     t.date "date", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "user_id"
+    t.index ["user_id"], name: "index_expenses_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -34,4 +36,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_02_171715) do
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
+
+  add_foreign_key "expenses", "users"
 end


### PR DESCRIPTION
## Purpose

This PR adds a `user_id` reference to the expenses table to start linking each expense to a specific user.