### PR TITLE
(feat): associate User with Expenses and add test coverage

### DIFF
--- a/app/models/expense.rb
+++ b/app/models/expense.rb
@@ -1,4 +1,6 @@
 class Expense < ApplicationRecord
+  belongs_to :user
+
   validates :name, presence: true
   validates :amount, presence: true, numericality: { greater_than: 0 }
   validates :date, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,6 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+  has_many :expenses, dependent: :destroy
 end

--- a/spec/factories/expenses.rb
+++ b/spec/factories/expenses.rb
@@ -1,5 +1,7 @@
 FactoryBot.define do
   factory :expense do
+    association :user
+
     name { "Internet Bill" }
     amount { 69.00 }
     date { Date.new(2025, 1, 31) }

--- a/spec/models/expense_spec.rb
+++ b/spec/models/expense_spec.rb
@@ -1,6 +1,10 @@
 require "rails_helper"
 
 RSpec.describe Expense, type: :model do
+  describe 'Associations' do
+    it { should belong_to(:user) }
+  end
+
   let(:expense) { build(:expense, name: name, amount: amount, date: date) }
   let(:name) { "Internet Bill" }
   let(:amount) { 69.00 }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,5 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'Associations' do
+    it { should have_many(:expenses).dependent(:destroy) }
+  end
 end


### PR DESCRIPTION
## Purpose

This PR introduces the model-level associations between users and expenses by:

- Adding `has_many :expenses` to the `User` model
- Adding `belongs_to :user` to the `Expense` model
- Updating the `Expense` factory to include a user
- Adding association tests for both models