### PR TITLE
(style): match forgot password page styling with custom app theme

### DIFF
--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,16 +1,24 @@
-<h2>Forgot your password?</h2>
+<div class="flex items-center justify-center min-h-screen bg-indigo-900 text-white">
+  <div class="w-full max-w-md p-8 space-y-6 bg-indigo-950 rounded-xl shadow-lg">
+    <h2 class="text-2xl font-bold text-center">Forgot your password?</h2>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+    <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+      <%= render "devise/shared/error_messages", resource: resource %>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+      <div class="space-y-4">
+        <div>
+          <%= f.label :email, class: "block text-sm font-medium text-white" %>
+          <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "mt-1 block w-full rounded-md bg-indigo-800 text-white border border-indigo-600 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-400" %>
+        </div>
+
+        <div>
+          <%= f.submit "Send me reset password instructions", class: "w-full bg-indigo-500 hover:bg-indigo-600 text-white font-semibold py-2 px-4 rounded-lg transition duration-150 ease-in-out cursor-pointer" %>
+        </div>
+      </div>
+    <% end %>
+
+    <div class="text-center text-sm mt-4">
+      <%= render "devise/shared/links" %>
+    </div>
   </div>
-
-  <div class="actions">
-    <%= f.submit "Send me reset password instructions" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>


### PR DESCRIPTION
## Purpose

This PR updates the look and feel of the Devise Forgot Password page to match the rest of the app using Tailwind CSS and a custom layout.

## Screenshot

<img width="1424" alt="Screenshot 2025-04-11 at 9 45 19 PM" src="https://github.com/user-attachments/assets/58aeb0df-eec5-49c6-8857-879557cbe172" />