### PR TITLE
(style): match reset password page styling with custom app theme

### DIFF
--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,25 +1,33 @@
-<h2>Change your password</h2>
+<div class="flex items-center justify-center min-h-screen bg-indigo-900 text-white">
+  <div class="w-full max-w-md p-8 space-y-6 bg-indigo-950 rounded-xl shadow-lg">
+    <h2 class="text-2xl font-bold text-center">Change your password</h2>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
-  <%= f.hidden_field :reset_password_token %>
+    <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
+      <%= render "devise/shared/error_messages", resource: resource %>
+      <%= f.hidden_field :reset_password_token %>
 
-  <div class="field">
-    <%= f.label :password, "New password" %><br />
-    <% if @minimum_password_length %>
-      <em>(<%= @minimum_password_length %> characters minimum)</em><br />
+      <div class="space-y-4">
+        <div>
+           <%= f.label :password, "New password", class: "block text-sm font-medium text-white" %>
+           <% if @minimum_password_length %>
+            <em>(<%= @minimum_password_length %> characters minimum)</em>
+          <% end %>
+          <%= f.password_field :password, autofocus: true, autocomplete: "new-password", class: "mt-1 block w-full rounded-md bg-indigo-800 text-white border border-indigo-600 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-400" %>
+        </div>
+
+        <div class="field">
+          <%= f.label :password_confirmation, "Confirm new password", class: "block text-sm font-medium text-white" %>
+          <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "mt-1 block w-full rounded-md bg-indigo-800 text-white border border-indigo-600 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-400" %>
+        </div>
+
+         <div>
+          <%= f.submit "Change my password", class: "w-full bg-indigo-500 hover:bg-indigo-600 text-white font-semibold py-2 px-4 rounded-lg transition duration-150 ease-in-out cursor-pointer"  %>
+         </div>
+      </div>
     <% end %>
-    <%= f.password_field :password, autofocus: true, autocomplete: "new-password" %>
-  </div>
 
-  <div class="field">
-    <%= f.label :password_confirmation, "Confirm new password" %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+    <div class="text-center text-sm mt-4">
+      <%= render "devise/shared/links" %>
+    </div>
   </div>
-
-  <div class="actions">
-    <%= f.submit "Change my password" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>


### PR DESCRIPTION
## Purpose

This PR updates the look and feel of the Devise Reset Password page to match the rest of the app using Tailwind CSS and a custom layout.

## Screenshot

<img width="1428" alt="Screenshot 2025-04-28 at 4 12 11 PM" src="https://github.com/user-attachments/assets/b95e7395-3d21-4473-ade9-191095c50b53" />