### PR TITLE
(fix): update rack gem to 3.1.14 to resolve security vulnerability

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -232,7 +232,7 @@ GEM
       nio4r (~> 2.0)
     raabro (1.4.0)
     racc (1.8.1)
-    rack (3.1.13)
+    rack (3.1.14)
     rack-session (2.1.0)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)


### PR DESCRIPTION
## Purpose

This PR updates the `rack` gem from version 3.1.13 to 3.1.14 to resolve a GitHub-reported security vulnerability.

## How to Test

1. Run `bundle install` to ensure dependencies are up to date.
2. Start the Rails server with `rails s`.
3. Confirm the app loads correctly and all major flows (sign in, CRUD operations) work as expected.